### PR TITLE
Map wss to https in forwarded headers

### DIFF
--- a/common/documentserver/nginx/includes/http-common.conf.m4
+++ b/common/documentserver/nginx/includes/http-common.conf.m4
@@ -19,6 +19,7 @@ map $http_cloudfront_forwarded_proto:$http_x_forwarded_proto $the_scheme {
      default $scheme;
      "~^https?:.*" $http_cloudfront_forwarded_proto;
      "~^:https?$" $http_x_forwarded_proto;
+     "~^:wss$" https;
 }
 
 map $http_x_forwarded_host $the_host {


### PR DESCRIPTION
Cherry-picks upstream commit [aa62a76](https://github.com/ONLYOFFICE/document-server-package/commit/aa62a7679ac1af9115b4e14f34508cdcd3318362).

Adds `"~^:wss$" https;` to the `$the_scheme` nginx map so a `wss` value in the forwarded proto headers is mapped to `https`, ensuring correct scheme resolution behind proxies that forward the WebSocket scheme.

Resolves Euro-Office/eurooffice-nextcloud#42